### PR TITLE
JSON serialization needs to be more than default of 2 levels

### DIFF
--- a/sumologic/SumoLogic.psm1
+++ b/sumologic/SumoLogic.psm1
@@ -92,7 +92,7 @@ function invokeSumoWebRequest($session,
     } else {
         $url = $session.Endpoint + $function
         debugRest $url $method $headers $content
-        Invoke-WebRequest -Uri $url -Headers $headers -Method $method -WebSession $session.WebSession -Body (ConvertTo-Json $content)
+        Invoke-WebRequest -Uri $url -Headers $headers -Method $method -WebSession $session.WebSession -Body (ConvertTo-Json $content -Depth 10)
     }
 }
 
@@ -111,7 +111,7 @@ function invokeSumoRestMethod($session,
     } else {
         $url = $session.Endpoint + $function
         debugRest $url $method $headers $content
-        Invoke-RestMethod -Uri $url -Headers $headers -Method $method -WebSession $session.WebSession -Body (ConvertTo-Json $content)
+        Invoke-RestMethod -Uri $url -Headers $headers -Method $method -WebSession $session.WebSession -Body (ConvertTo-Json $content -Depth 10)
     }
 }
 


### PR DESCRIPTION
Ref https://github.com/SumoLogic/sumo-powershell-sdk/issues/2

Newly-enabled timestamp configuration settings create an array of nested objects attached to sources. Thus when serializing a source object to JSON, we need to make sure the serialization depth captures the nested objects.

Default depth is 2, which is not enough: timestamp config object gets squashed into a `ToString` version of itself which doesn't pass validation.

Fix for now is to boost JSON depth to 10.