### PR TITLE
Add filtering options to get-collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ __NOTE__: This module requires PowerShell 3.0 or higher to work.
 ### 3. Run samples
 Launch `Sample.ps1` under `sample` folder and try some examples 
 
+### 4. Get-Collector For Accounts Over 1000 Collectors
+Results returned from the SumoLogic collector API default to a 1000 limit. 
+This means if you have more than 1000 collectors you need to use -Limit and -Offset arguments or you will get incomplete results.
+
+For example say we more than 1000 collectors, and several hundred collectors with 'test' in the name property. The code below demonstrates how adding -Limit and -Offset will fix the problem that the default limit 1000 returns an incomplete result set.
+
+```
+# This returns 56 results - ONLY the collectors matching test from the first 1000 returned by the API.
+(Get-collector | where {$_.name -match 'test' } ).count
+56
+
+# Now setting a limit of 10000 we get the complete result set of 219 matching string 'test' by name
+(Get-collector -Limit 10000 -Offset 0  | where {$_.name -match 'test' } ).count                                                219
+
+ ```
+
 ## Issues and Feature Request
 Report any issue or idea through [Git Hub](https://github.com/SumoLogic/sumo-powershell-sdk)
 

--- a/sample/Sample.ps1
+++ b/sample/Sample.ps1
@@ -8,7 +8,7 @@ Get-Credential | New-SumoSession -Deployment Prod
 # Create session by giving access id and key in code
 # $session = New-SumoSession -Deployment Prod -AccessId "xxxxxxxxx" -AccessKey 'yyyyyyyyyyyyyyyyyyyuyuu'
 
-# Get all collectors
+# Get all collectors (If you have more than 1000 you must use -Offset syntax to get all of them!)
 Get-Collector
 
 # Get all collectors by page
@@ -49,4 +49,26 @@ Start-SearchJob -Query "*exception*" -Last ([TimeSpan]::FromHours(1)) | Get-Sear
 
 # search formatted exceptions and count the number with groups 
 Start-SearchJob -Query '*exception* | timeslice 1h | split _raw delim='' '' extract _, _, _, level, _, host | count group level, host' | Get-SearchResult -Type Record
+
+# extra filtering by collector properties
+
+# filter for Hosted or Installable collector types only
+Get-Collector -Limit 10000 -Offset 0 -Verbose -collectorType Installable 
+Get-Collector -ByName -NamePattern 'sometext' -Verbose -collectorType Hosted 
+
+# filter by JSON sync mode or not
+Get-Collector -limit 10000 -Offset 0 -sourceSyncMode UI -Verbose  
+Get-Collector -ByName -NamePattern 'sometext' -sourceSyncMode JSON 
+
+# Filtering Using FilterProperties
+# other types of filtering can be achieved this way by passing a hash of properties
+
+# turn on -verbose to get some info about if filtering is working as expected
+Get-Collector -ByName -NamePattern 'sometext' -FilterProperties @{"ephemeral" = $false} -Verbose
+
+# agents that are not reporting to sumo
+Get-Collector -limit 10000 -Offset 0 -FilterProperties @{ "alive" = $false }  
+
+# you can include multiple FilterProperties at onceß
+Get-Collector -limit 10000 -Offset 0 -FilterProperties @{ "sourceSyncMode" = "UI"; "alive" = $false; "ephemeral" = $false }
 

--- a/sample/Sample.ps1
+++ b/sample/Sample.ps1
@@ -8,10 +8,11 @@ Get-Credential | New-SumoSession -Deployment Prod
 # Create session by giving access id and key in code
 # $session = New-SumoSession -Deployment Prod -AccessId "xxxxxxxxx" -AccessKey 'yyyyyyyyyyyyyyyyyyyuyuu'
 
-# Get all collectors (If you have more than 1000 you must use -Offset syntax to get all of them!)
+# Get all collectors 
 Get-Collector
 
 # Get all collectors by page
+# If you have more than 1000 you must use -Limit and -Offset to get complete results!
 Get-Collector -Offset 3 -Limit 5
 
 # Get collector by Id
@@ -50,13 +51,17 @@ Start-SearchJob -Query "*exception*" -Last ([TimeSpan]::FromHours(1)) | Get-Sear
 # search formatted exceptions and count the number with groups 
 Start-SearchJob -Query '*exception* | timeslice 1h | split _raw delim='' '' extract _, _, _, level, _, host | count group level, host' | Get-SearchResult -Type Record
 
-# extra filtering by collector properties
+# Filtering Get-Collector results using other properties
 
 # filter for Hosted or Installable collector types only
-Get-Collector -Limit 10000 -Offset 0 -Verbose -collectorType Installable 
+Get-Collector -collectorType Installable 
 Get-Collector -ByName -NamePattern 'sometext' -Verbose -collectorType Hosted 
 
+# for more than 1000 collectors you must add -Limit greater than your total collector count or you might get incomplete results.
+Get-Collector -Limit 10000 -Offset 0 -collectorType Installable -Verbose
+
 # filter by JSON sync mode or not
+Get-Collector -sourceSyncMode UI -Verbose  
 Get-Collector -limit 10000 -Offset 0 -sourceSyncMode UI -Verbose  
 Get-Collector -ByName -NamePattern 'sometext' -sourceSyncMode JSON 
 
@@ -69,6 +74,6 @@ Get-Collector -ByName -NamePattern 'sometext' -FilterProperties @{"ephemeral" = 
 # agents that are not reporting to sumo
 Get-Collector -limit 10000 -Offset 0 -FilterProperties @{ "alive" = $false }  
 
-# you can include multiple FilterProperties at onceß
+# you can include multiple FilterProperties at once
 Get-Collector -limit 10000 -Offset 0 -FilterProperties @{ "sourceSyncMode" = "UI"; "alive" = $false; "ephemeral" = $false }
 


### PR DESCRIPTION
I have added two simple filter options for simple use cases
- sourceSyncMode
- collectorType

and one advanced filter option where you can pass a hashtable of property / value pairs for other use cases (such as filtering by ephemeral, alive, osVer etc)

This simplifies interacting with get-collector as it means you can do filtering for most common use cases without resorting to extra | where ... clauses.

I have added examples of use to samples doc and some verbose logging for testing if your filtering is doing what you expected.

Example:
```
$c=Get-Collector -limit 10000 -Offset 0 -FilterProperties @{ "sourceSyncMode" = "UI"; "alive" = $false; "ephemeral" = $false } -Verbose                                                             
VERBOSE: GET https://api.us2.sumologic.com/api/v1/collectors?limit=10000&offset=0& with 0-byte payload
VERBOSE: received -byte response of content type application/json
VERBOSE: Content encoding: iso-8859-1
VERBOSE: Returned 4060 collectors before filtering
VERBOSE: filter on FilterProperties property: alive -eq False 
VERBOSE: filter on FilterProperties property: ephemeral -eq False 
VERBOSE: filter on FilterProperties property: sourceSyncMode -eq UI 
VERBOSE: There are 18 collectors after filtering
```
