### PR TITLE
sdk as a Docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,27 @@
+FROM microsoft/powershell:latest
+
+# default environment processing
+#ENV SUMO_DEPLOYMENT=US2
+ENV SUMO_SESSION=false
+
+# A simple script to get up to 10 collectors via the API
+COPY demo.ps1 /home/demo.ps1
+RUN chmod +x /home/demo.ps1
+
+# put more stuff in the container yourself say another script
+#COPY myfile.ps1 /home/myfile.ps1
+#RUN chmod +x /home/myfile.ps1
+
+################################################################
+RUN mkdir ./psm 
+RUN pwsh -c "Save-Module SumoLogic-Core -Path ./psm -Repository PSGallery"
+
+# setup a profile to launch the module import and a connection if session=true
+RUN mkdir -p /root/.config/powershell
+COPY profile.ps1 /root/.config/powershell/profile.ps1
+RUN chmod +x /root/.config/powershell/profile.ps1
+
+ENTRYPOINT ["pwsh"]
+
+# to execute your own custom script include this in the container using COPY or map a volume and modify the entrypoint e.g
+# ENTRYPOINT ["pwsh","-File","/home/demo.ps1"]

--- a/docker/demo.ps1
+++ b/docker/demo.ps1
@@ -1,3 +1,3 @@
 $collectors=Get-Collector -limit 10 -Offset 1 #-verbose
-Write-Host $collectors | Sort-Object
+Write-Host $collectors.name | Sort-Object
 Write-Output $collectors.count 

--- a/docker/demo.ps1
+++ b/docker/demo.ps1
@@ -1,0 +1,3 @@
+$collectors=Get-Collector -limit 10 -Offset 1 #-verbose
+Write-Host $collectors | Sort-Object
+Write-Output $collectors.count 

--- a/docker/profile.ps1
+++ b/docker/profile.ps1
@@ -1,0 +1,30 @@
+
+Import-Module -Name (Get-ChildItem -Filter *psd1 -Recurse ./psm/).FullName
+
+if ($Env:SUMO_DEPLOYMENT -imatch '.+' -and $Env:SUMO_DEPLOYMENT -inotmatch 'prod') {
+   $env:SUMOLOGIC_API_ENDPOINT="https://api.$(($Env:SUMO_DEPLOYMENT).ToLower()).sumologic.com/api/v1/"
+   write-host "SUMOLOGIC_API_ENDPOINT is: $($env:SUMOLOGIC_API_ENDPOINT)"
+} else {
+   Write-Verbose 'SUMO_DEPLOYMENT is default'
+}
+
+if ((Get-Module -Name SumoLogic-Core).Name -ne "Sumologic-Core") {
+   write-error "ERROR module import probably failed!"
+} else {
+   write-host "Welcome to Sumologic-Core: https://github.com/SumoLogic/sumo-powershell-sdk! `n`nTo see available commands:`nget-command -Module Sumologic-Core`n"
+
+   if ($Env:SUMO_SESSION -eq $true) {
+      if (!$Env:SUMO_ACCESS_ID -or !$Env:SUMO_ACCESS_KEY  ) { 
+           write-host "ERROR SUMO_SESSION is set but you must set SUMO_DEPLOYMENT,SUMO_ACCESS_KEY and SUMO_ACCESS_KEY to run `nNew-SumoSession -Deployment `$Env:SUMO_DEPLOYMENT -AccessId `$Env:SUMO_ACCESS_ID -AccessKey `$Env:SUMO_ACCESS_KEY `nYou will need to make your own New-SumoSession" ; 
+          
+        } else {
+           write-host 'SUMO_SESSION is true... making New-SumoSession'
+           $accessKeyAsSecureString = ConvertTo-SecureString $Env:SUMO_ACCESS_KEY -AsPlainText -Force
+           New-SumoSession -AccessId $Env:SUMO_ACCESS_ID -AccessKey $accessKeyAsSecureString
+        }
+       
+   } else {
+       write-host 'SUMO_SESSION is false, you must make your own with New-SumoSession '
+   }
+}
+

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -1,0 +1,43 @@
+#  sumologic powershell sdk on as a .net core linux container
+
+This is a container based on [powershell for .net core / linux container](https://hub.docker.com/r/microsoft/powershell/) that has the [sumologic powershell sdk](https://github.com/SumoLogic/sumo-powershell-sdk) pre loaded.
+
+# Making a session
+If you set SUMO_SESSION to ```true``` on startup the container will iniate a session env vars:
+- SUMO_DEPLOYMENT (see https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security). This is converted into the SUMOLOGIC_API_ENDPOINT
+
+## credentials:
+https://github.com/SumoLogic/sumo-powershell-sdk#4-start-to-use-cmdlets
+- SUMO_ACCESS_ID
+- SUMO_ACCESS_KEY
+
+# custom entry point
+By default a pwsh prompt is the entry point. .
+Then modify the entrypoint e.g
+```
+ENTRYPOINT ["pwsh","-File","/home/demo.ps1"]
+```
+
+# Build the docker container
+to build run
+```
+docker build -t sumologic-powershell-sdk:latest .
+```
+
+# Starting the container
+
+## windows powershell
+```
+docker run --env SUMO_DEPLOYMENT=US2 --env SUMO_ACCESS_ID=$Env:SUMO_ACCESS_ID --env SUMO_ACCESS_KEY=$Env:SUMO_
+ACCESS_KEY -it sumologic-powershell-sdk:latest
+```
+
+## bash
+```
+docker run --env SUMO_DEPLOYMENT=AU --env SUMO_ACCESS_ID=$SUMO_ACCESS_ID --env SUMO_ACCESS_KEY=$SUMO_ACCESS_KEY -it sumologic-powershell-sdk:latest
+```
+
+# Running the demo.ps1 script
+```
+docker run --env SUMO_SESSION=true --env SUMO_DEPLOYMENT=AU --env SUMO_ACCESS_ID=$SUMO_ACCESS_ID --env SUMO_ACCESS_KEY=$SUMO_ACCESS_KEY --entrypoint pwsh  sumologic-powershell-sdk:latest -File /home/demo.ps1
+```

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -3,11 +3,8 @@
 This is a container based on [powershell for .net core / linux container](https://hub.docker.com/r/microsoft/powershell/) that has the [sumologic powershell sdk](https://github.com/SumoLogic/sumo-powershell-sdk) pre loaded.
 
 # Making a session
-If you set SUMO_SESSION to ```true``` on startup the container will iniate a session env vars:
+If you set SUMO_SESSION to ```true``` on startup the container will iniate a session using env vars:
 - SUMO_DEPLOYMENT (see https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security). This is converted into the SUMOLOGIC_API_ENDPOINT
-
-## credentials:
-https://github.com/SumoLogic/sumo-powershell-sdk#4-start-to-use-cmdlets
 - SUMO_ACCESS_ID
 - SUMO_ACCESS_KEY
 
@@ -40,4 +37,9 @@ docker run --env SUMO_DEPLOYMENT=AU --env SUMO_ACCESS_ID=$SUMO_ACCESS_ID --env S
 # Running the demo.ps1 script
 ```
 docker run --env SUMO_SESSION=true --env SUMO_DEPLOYMENT=AU --env SUMO_ACCESS_ID=$SUMO_ACCESS_ID --env SUMO_ACCESS_KEY=$SUMO_ACCESS_KEY --entrypoint pwsh  sumologic-powershell-sdk:latest -File /home/demo.ps1
+```
+
+# Running a command on container launch
+```
+docker run --env SUMO_SESSION=true --env SUMO_DEPLOYMENT=AU --env SUMO_ACCESS_ID=$SUMO_ACCESS_ID --env SUMO_ACCESS_KEY=$SUMO_ACCESS_KEY -it --entrypoint pwsh sumologic-powershell-sdk:latest -c "get-collector -limit 10 -offset 0"
 ```


### PR DESCRIPTION
This is how to run the powershell sdk as a .net core linux container.  

Having the sdk as a container is useful for:
- automation: run any ps script in a docker environment: for example a batch job to perform collector cleanup via API.
- portability: run powershell sumo sdk without having to do any setup
- ci/cd: start containers as part of a deployment process to say run queries vs collector or search job api.
- testing features: start the container and load a custom version of the powershell module instead of the powershell gallery one in ./psm/